### PR TITLE
Place property names inside board color bands

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -19,6 +19,7 @@ const Board: React.FC<BoardProps> = ({ ownership, players, currentPlayerId }) =>
           const owned = ownership[space.id]
           const owner = owned?.ownerId != null ? players.find((player) => player.id === owned.ownerId && !player.bankrupt) : undefined
           const playersHere = players.filter((player) => !player.bankrupt && player.position === space.id)
+          const showNameBelow = space.type !== 'property'
 
           return (
             <div
@@ -33,9 +34,11 @@ const Board: React.FC<BoardProps> = ({ ownership, players, currentPlayerId }) =>
                 style={owner ? { boxShadow: `0 0 0 2px ${owner.color}55` } : undefined}
               >
                 <SpaceContent space={space} owned={owned} />
-                <div className="mt-1 min-h-[24px] break-words px-[2px] text-center text-[8px] font-semibold leading-tight tracking-tight text-neutral-900">
-                  {space.shortName ?? space.name}
-                </div>
+                {showNameBelow && (
+                  <div className="mt-1 min-h-[24px] break-words px-[2px] text-center text-[8px] font-semibold leading-tight tracking-tight text-neutral-900">
+                    {space.shortName ?? space.name}
+                  </div>
+                )}
                 <div className="px-[2px] text-center text-[7px] font-semibold uppercase tracking-tight text-neutral-500">
                   {renderSpaceSubtitle(space)}
                 </div>
@@ -77,10 +80,15 @@ interface SpaceContentProps {
 
 const SpaceContent: React.FC<SpaceContentProps> = ({ space, owned }) => {
   if (space.type === 'property') {
-    const color = COLOR_GROUP_DISPLAY[space.color].color
+    const colorInfo = COLOR_GROUP_DISPLAY[space.color]
     return (
       <div className="flex flex-col items-center gap-1">
-        <div className="h-3 rounded-sm" style={{ backgroundColor: color }} />
+        <div
+          className="flex w-full min-h-[18px] items-center justify-center rounded-sm px-[2px] py-[1px] text-center text-[7px] font-semibold uppercase leading-tight tracking-tight"
+          style={{ backgroundColor: colorInfo.color, color: colorInfo.textColor }}
+        >
+          <span className="block w-full break-words">{space.shortName ?? space.name}</span>
+        </div>
         <BuildingDisplay houses={owned?.houses ?? 0} />
       </div>
     )

--- a/src/data/board.ts
+++ b/src/data/board.ts
@@ -388,15 +388,15 @@ export const BOARD_SPACES: BoardSpace[] = [
   },
 ]
 
-export const COLOR_GROUP_DISPLAY: Record<ColorGroup, { label: string; color: string }> = {
-  brown: { label: 'Brown', color: '#955436' },
-  'light-blue': { label: 'Light Blue', color: '#9ad8f7' },
-  magenta: { label: 'Magenta', color: '#d94fa6' },
-  orange: { label: 'Orange', color: '#f89736' },
-  red: { label: 'Red', color: '#e63946' },
-  yellow: { label: 'Yellow', color: '#f9c74f' },
-  green: { label: 'Green', color: '#2a9d8f' },
-  'dark-blue': { label: 'Dark Blue', color: '#264653' },
+export const COLOR_GROUP_DISPLAY: Record<ColorGroup, { label: string; color: string; textColor: string }> = {
+  brown: { label: 'Brown', color: '#955436', textColor: '#fdf2e9' },
+  'light-blue': { label: 'Light Blue', color: '#9ad8f7', textColor: '#1f2937' },
+  magenta: { label: 'Magenta', color: '#d94fa6', textColor: '#fef2f9' },
+  orange: { label: 'Orange', color: '#f89736', textColor: '#1f2937' },
+  red: { label: 'Red', color: '#e63946', textColor: '#fff5f5' },
+  yellow: { label: 'Yellow', color: '#f9c74f', textColor: '#1f2937' },
+  green: { label: 'Green', color: '#2a9d8f', textColor: '#ecfdf5' },
+  'dark-blue': { label: 'Dark Blue', color: '#264653', textColor: '#f8fafc' },
 }
 
 export const PROPERTY_IDS_BY_COLOR = BOARD_SPACES.reduce<Record<ColorGroup, number[]>>((acc, space) => {


### PR DESCRIPTION
## Summary
- show property names directly inside each property's color band
- avoid rendering the separate floating name label for property spaces
- add per-color text hues so labels stay legible against each band

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8fd640b2083229838ca2052c1d460